### PR TITLE
pypy virtualenv support

### DIFF
--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -207,3 +207,57 @@ def test_not_a_virtualenv_missing_site_packages(fake_venv, capsys):
         fake_venv, fake_venv.join('lib/python2.7/site-packages'),
     )
     assert out == expected
+
+
+@pytest.yield_fixture
+def fake_pypy_venv(tmpdir):
+    tmpdir.join('bin').ensure_dir()
+    tmpdir.join('lib_pypy').ensure_dir()
+    tmpdir.join('site-packages').ensure_dir()
+    tmpdir.join('lib-python/py27').ensure_dir()
+    tmpdir.join('bin/activate').write('VIRTUAL_ENV=/venv')
+    yield tmpdir
+
+
+def test_pypy_not_a_virtualenv_missing_bindir(fake_pypy_venv, capsys):
+    fake_pypy_venv.join('bin').remove()
+    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
+    out, _ = capsys.readouterr()
+    assert ret == 1
+    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
+        fake_pypy_venv, fake_pypy_venv.join('bin'),
+    )
+    assert out == expected
+
+
+def test_pypy_not_a_virtualenv_missing_activate_file(fake_pypy_venv, capsys):
+    fake_pypy_venv.join('bin/activate').remove()
+    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
+    out, _ = capsys.readouterr()
+    assert ret == 1
+    expected = '{} is not a virtualenv: not a file: {}\n'.format(
+        fake_pypy_venv, fake_pypy_venv.join('bin/activate'),
+    )
+    assert out == expected
+
+
+def test_pypy_not_a_virtualenv_missing_versioned_lib_directory(fake_pypy_venv, capsys):
+    fake_pypy_venv.join('lib-python/py27').remove()
+    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
+    out, _ = capsys.readouterr()
+    assert ret == 1
+    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
+        fake_pypy_venv, fake_pypy_venv.join('lib-python/py##'),
+    )
+    assert out == expected
+
+
+def test_pypy_not_a_virtualenv_missing_site_packages(fake_pypy_venv, capsys):
+    fake_pypy_venv.join('site-packages').remove()
+    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
+    out, _ = capsys.readouterr()
+    assert ret == 1
+    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
+        fake_pypy_venv, fake_pypy_venv.join('site-packages'),
+    )
+    assert out == expected

--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -1,6 +1,5 @@
 import collections
 import pipes
-import shutil
 import subprocess
 import sys
 
@@ -163,8 +162,8 @@ class TestVirtualenvTools(object):
 
 
 @pytest.mark.skipif(
-    sys.version_info >= (3, 3) and not shutil.which('pypy3'),
-    reason="pypy3 is required to run these tests under python3.3+"
+    sys.version_info >= (3, 3),
+    reason='pypy3 is not supported yet.'
 )
 class TestVirtualenvToolsPyPy(TestVirtualenvTools):
 

--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -1,5 +1,6 @@
 import collections
 import pipes
+import shutil
 import subprocess
 import sys
 
@@ -46,354 +47,231 @@ def run(before, after, args=()):
     assert ret == 0
 
 
-@pytest.mark.parametrize('helpargs', ((), ('--help',)))
-def test_help(capsys, helpargs):
-    with pytest.raises(SystemExit):
-        virtualenv_tools.main(helpargs)
-    out, err = capsys.readouterr()
-    assert 'usage: ' in out + err
-
-
-def test_already_up_to_date(venv, capsys):
-    run(venv.before, venv.before)
-    out, _ = capsys.readouterr()
-    assert out == 'Already up-to-date: {0} ({0})\n'.format(venv.before)
-
-
-def test_each_part_idempotent(tmpdir, venv, capsys):
-    activate = venv.before.join('bin/activate')
-    before_activate_contents = activate.read()
-    run(venv.before, venv.after)
-    capsys.readouterr()
-    # Write the activate file to trick the logic into rerunning
-    activate.write(before_activate_contents)
-    run(venv.before, venv.after, args=('--verbose',))
-    out, _ = capsys.readouterr()
-    # Should only update our activate file:
-    expected = 'A {0}\nUpdated: {1} ({1} -> {2})\n'.format(
-        activate, venv.before, venv.after,
-    )
-    assert out == expected
-
-
-def _assert_activated_sys_executable(path):
+def _assert_activated_sys_executable(path, python):
     exe = subprocess.check_output((
         'bash', '-c',
-        ". {} && python -c 'import sys; print(sys.executable)'".format(
+        ". {} && {} -c 'import sys; print(sys.executable)'".format(
             pipes.quote(path.join('bin/activate').strpath),
+            python
         )
     )).decode('UTF-8').strip()
-    assert exe == path.join('bin/python').strpath
+    assert exe == path.join('bin/{}'.format(python)).strpath
 
 
-def _assert_mymodule_output(path):
+def _assert_mymodule_output(path, python):
     out = subprocess.check_output(
-        (path.join('bin/python').strpath, '-m', 'mymodule'),
+        (path.join('bin/{}'.format(python)).strpath, '-m', 'mymodule'),
         # Run from '/' to ensure we're not importing from .
         cwd='/',
     ).decode('UTF-8')
     assert out == 'ohai!\n'
 
 
-def assert_virtualenv_state(path):
-    _assert_activated_sys_executable(path)
-    _assert_mymodule_output(path)
+class TestVirtualenvTools(object):
 
+    def assert_virtualenv_state(self, path):
+        _assert_activated_sys_executable(path, 'python')
+        _assert_mymodule_output(path, 'python')
 
-def test_move(venv, capsys):
-    assert_virtualenv_state(venv.before)
-    run(venv.before, venv.after)
-    out, _ = capsys.readouterr()
-    expected = 'Updated: {0} ({0} -> {1})\n'.format(venv.before, venv.after)
-    assert out == expected
-    venv.app_before.move(venv.app_after)
-    assert_virtualenv_state(venv.after)
+    @pytest.mark.parametrize('helpargs', ((), ('--help',)))
+    def test_help(self, capsys, helpargs):
+        with pytest.raises(SystemExit):
+            virtualenv_tools.main(helpargs)
+        out, err = capsys.readouterr()
+        assert 'usage: ' in out + err
 
+    def test_already_up_to_date(self, venv, capsys):
+        run(venv.before, venv.before)
+        out, _ = capsys.readouterr()
+        assert out == 'Already up-to-date: {0} ({0})\n'.format(venv.before)
 
-def test_move_with_auto(venv, capsys):
-    venv.app_before.move(venv.app_after)
-    ret = virtualenv_tools.main(('--update-path=auto', venv.after.strpath))
-    out, _ = capsys.readouterr()
-    expected = 'Updated: {1} ({0} -> {1})\n'.format(venv.before, venv.after)
-    assert ret == 0
-    assert out == expected
-    assert_virtualenv_state(venv.after)
+    def test_each_part_idempotent(self, tmpdir, venv, capsys):
+        activate = venv.before.join('bin/activate')
+        before_activate_contents = activate.read()
+        run(venv.before, venv.after)
+        capsys.readouterr()
+        # Write the activate file to trick the logic into rerunning
+        activate.write(before_activate_contents)
+        run(venv.before, venv.after, args=('--verbose',))
+        out, _ = capsys.readouterr()
+        # Should only update our activate file:
+        expected = 'A {0}\nUpdated: {1} ({1} -> {2})\n'.format(
+            activate, venv.before, venv.after,
+        )
+        assert out == expected
 
+    def test_move(self, venv, capsys):
+        self.assert_virtualenv_state(venv.before)
+        run(venv.before, venv.after)
+        out, _ = capsys.readouterr()
+        expected = 'Updated: {0} ({0} -> {1})\n'.format(
+            venv.before,
+            venv.after
+        )
+        assert out == expected
+        venv.app_before.move(venv.app_after)
+        self.assert_virtualenv_state(venv.after)
 
-def test_bad_pyc(venv, capsys):
+    def test_move_with_auto(self, venv, capsys):
+        venv.app_before.move(venv.app_after)
+        ret = virtualenv_tools.main(('--update-path=auto', venv.after.strpath))
+        out, _ = capsys.readouterr()
+        expected = 'Updated: {1} ({0} -> {1})\n'.format(
+            venv.before,
+            venv.after
+        )
+        assert ret == 0
+        assert out == expected
+        self.assert_virtualenv_state(venv.after)
+
     libdir = 'lib/python{}.{}'.format(*sys.version_info[:2])
-    bad_pyc = venv.before.join(libdir, 'bad.pyc')
-    bad_pyc.write_binary(b'I am a very naughty pyc\n')
-    # Retries on failures as well
-    for _ in range(2):
-        with pytest.raises(ValueError):
-            run(venv.before, venv.after)
+
+    def test_bad_pyc(self, venv, capsys):
+        bad_pyc = venv.before.join(self.libdir, 'bad.pyc')
+        bad_pyc.write_binary(b'I am a very naughty pyc\n')
+        # Retries on failures as well
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                run(venv.before, venv.after)
+            out, _ = capsys.readouterr()
+            assert out == 'Error in {}\n'.format(bad_pyc.strpath)
+
+    def test_dir_oddities(self, venv):
+        bindir = venv.before.join('bin')
+        # A directory existing in the bin dir
+        bindir.join('im_a_directory').ensure_dir()
+        # A broken symlink
+        bindir.join('bad_symlink').mksymlinkto('/i/dont/exist')
+        # A file with a shebang-looking start, but not actually
+        bindir.join('not-an-exe').write('#!\nohai')
+        run(venv.before, venv.after)
+
+    expected_min_verbose_line_count = 50
+
+    def test_verbose(self, venv, capsys):
+        run(venv.before, venv.after, args=('--verbose',))
         out, _ = capsys.readouterr()
-        assert out == 'Error in {}\n'.format(bad_pyc.strpath)
+        # Lots of output
+        print (out)
+        assert len(out.splitlines()) >= self.expected_min_verbose_line_count
+
+    def test_non_absolute_error(self, capsys):
+        ret = virtualenv_tools.main(('--update-path', 'notabs'))
+        out, _ = capsys.readouterr()
+        assert ret == 1
+        assert out == '--update-path must be absolute: notabs\n'
 
 
-def test_dir_oddities(venv):
-    bindir = venv.before.join('bin')
-    # A directory existing in the bin dir
-    bindir.join('im_a_directory').ensure_dir()
-    # A broken symlink
-    bindir.join('bad_symlink').mksymlinkto('/i/dont/exist')
-    # A file with a shebang-looking start, but not actually
-    bindir.join('not-an-exe').write('#!\nohai')
-    run(venv.before, venv.after)
+@pytest.mark.skipif(
+    sys.version_info >= (3, 3) and not shutil.which('pypy3'),
+    reason="pypy3 is required to run these tests under python3.3+"
+)
+class TestVirtualenvToolsPyPy(TestVirtualenvTools):
 
+    def assert_virtualenv_state(self, path):
+        _assert_activated_sys_executable(path, 'pypy')
+        _assert_mymodule_output(path, 'pypy')
 
-def test_verbose(venv, capsys):
-    run(venv.before, venv.after, args=('--verbose',))
-    out, _ = capsys.readouterr()
-    # Lots of output
-    print (out)
-    assert len(out.splitlines()) > 50
-
-
-def test_non_absolute_error(capsys):
-    ret = virtualenv_tools.main(('--update-path', 'notabs'))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    assert out == '--update-path must be absolute: notabs\n'
-
-
-@pytest.yield_fixture
-def fake_venv(tmpdir):
-    tmpdir.join('bin').ensure_dir()
-    tmpdir.join('lib/python2.7/site-packages').ensure_dir()
-    tmpdir.join('bin/activate').write('VIRTUAL_ENV=/venv')
-    yield tmpdir
-
-
-def test_not_a_virtualenv_missing_bindir(fake_venv, capsys):
-    fake_venv.join('bin').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
-        fake_venv, fake_venv.join('bin'),
-    )
-    assert out == expected
-
-
-def test_not_a_virtualenv_missing_activate_file(fake_venv, capsys):
-    fake_venv.join('bin/activate').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a file: {}\n'.format(
-        fake_venv, fake_venv.join('bin/activate'),
-    )
-    assert out == expected
-
-
-def test_not_a_virtualenv_missing_versioned_lib_directory(fake_venv, capsys):
-    fake_venv.join('lib/python2.7').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
-        fake_venv, fake_venv.join('lib/python#.#'),
-    )
-    assert out == expected
-
-
-def test_not_a_virtualenv_missing_site_packages(fake_venv, capsys):
-    fake_venv.join('lib/python2.7/site-packages').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
-        fake_venv, fake_venv.join('lib/python2.7/site-packages'),
-    )
-    assert out == expected
-
-
-
-
-# pypy tests temp--------------------
-
-
-@pytest.yield_fixture
-def venv_pypy(tmpdir):
-    app_before = tmpdir.join('before').ensure_dir()
-    app_before.join('mymodule.py').write(
-        "if __name__ == '__main__':\n"
-        "    print('ohai!')\n"
-    )
-    app_before.join('setup.py').write(
-        'from setuptools import setup\n'
-        'setup(name="mymodule", py_modules=["mymodule"])\n'
-    )
-    venv_before = app_before.join('venv')
-    app_after = tmpdir.join('after')
-    venv_after = app_after.join('venv')
-
-    cmd = (sys.executable, '-m', 'virtualenv', venv_before.strpath, '-p', 'pypy')
-    subprocess.check_call(cmd)
-    subprocess.check_call((
-        venv_before.join('bin/pip').strpath,
-        'install', '-e', app_before.strpath,
-    ))
-    yield auto_namedtuple(
-        app_before=app_before, app_after=app_after,
-        before=venv_before, after=venv_after,
-    )
-
-
-def _assert_activated_pypy_sys_executable(path):
-    exe = subprocess.check_output((
-        'bash', '-c',
-        ". {} && pypy -c 'import sys; print(sys.executable)'".format(
-            pipes.quote(path.join('bin/activate').strpath),
+    @pytest.yield_fixture
+    def venv(self, tmpdir):
+        app_before = tmpdir.join('before').ensure_dir()
+        app_before.join('mymodule.py').write(
+            "if __name__ == '__main__':\n"
+            "    print('ohai!')\n"
         )
-    )).decode('UTF-8').strip()
-    assert exe == path.join('bin/pypy').strpath
+        app_before.join('setup.py').write(
+            'from setuptools import setup\n'
+            'setup(name="mymodule", py_modules=["mymodule"])\n'
+        )
+        venv_before = app_before.join('venv')
+        app_after = tmpdir.join('after')
+        venv_after = app_after.join('venv')
 
+        cmd = (sys.executable, '-m', 'virtualenv', venv_before.strpath,
+               '-p', 'pypy' if sys.version_info < (3, 3) else 'pypy3')
+        subprocess.check_call(cmd)
+        subprocess.check_call((
+            venv_before.join('bin/pip').strpath,
+            'install', '-e', app_before.strpath,
+        ))
+        yield auto_namedtuple(
+            app_before=app_before, app_after=app_after,
+            before=venv_before, after=venv_after,
+        )
 
-def _assert_mymodule_pypy_output(path):
-    out = subprocess.check_output(
-        (path.join('bin/python').strpath, '-m', 'mymodule'),
-        # Run from '/' to ensure we're not importing from .
-        cwd='/',
-    ).decode('UTF-8')
-    assert out == 'ohai!\n'
-
-
-def assert_virtualenv_pypy_state(path):
-    _assert_activated_pypy_sys_executable(path)
-    _assert_mymodule_pypy_output(path)
-
-
-def test_pypy_already_up_to_date(venv_pypy, capsys):
-    run(venv_pypy.before, venv_pypy.before)
-    out, _ = capsys.readouterr()
-    assert out == 'Already up-to-date: {0} ({0})\n'.format(venv_pypy.before)
-
-
-def test_pypy_each_part_idempotent(tmpdir, venv_pypy, capsys):
-    venv = venv_pypy
-    activate = venv.before.join('bin/activate')
-    before_activate_contents = activate.read()
-    run(venv.before, venv.after)
-    capsys.readouterr()
-    # Write the activate file to trick the logic into rerunning
-    activate.write(before_activate_contents)
-    run(venv.before, venv.after, args=('--verbose',))
-    out, _ = capsys.readouterr()
-    # Should only update our activate file:
-    expected = 'A {0}\nUpdated: {1} ({1} -> {2})\n'.format(
-        activate, venv.before, venv.after,
-    )
-    assert out == expected
-
-
-def test_pypy_move(venv_pypy, capsys):
-    venv = venv_pypy
-    assert_virtualenv_pypy_state(venv.before)
-    run(venv.before, venv.after)
-    out, _ = capsys.readouterr()
-    expected = 'Updated: {0} ({0} -> {1})\n'.format(venv.before, venv.after)
-    assert out == expected
-    venv.app_before.move(venv.app_after)
-    assert_virtualenv_pypy_state(venv.after)
-
-
-def test_pypy_move_with_auto(venv_pypy, capsys):
-    venv = venv_pypy
-    venv.app_before.move(venv.app_after)
-    ret = virtualenv_tools.main(('--update-path=auto', venv.after.strpath))
-    out, _ = capsys.readouterr()
-    expected = 'Updated: {1} ({0} -> {1})\n'.format(venv.before, venv.after)
-    assert ret == 0
-    assert out == expected
-    assert_virtualenv_pypy_state(venv.after)
-
-
-def test_pypy_bad_pyc(venv_pypy, capsys):
-    venv = venv_pypy
     libdir = 'lib-python/{}.{}'.format(*sys.version_info[:2])
-    bad_pyc = venv.before.join(libdir, 'bad.pyc')
-    bad_pyc.write_binary(b'I am a very naughty pyc\n')
-    # Retries on failures as well
-    for _ in range(2):
-        with pytest.raises(ValueError):
-            run(venv.before, venv.after)
+    expected_min_verbose_line_count = 30
+
+
+class TestVirtualenvToolsFakeVenv(object):
+
+    @pytest.yield_fixture
+    def fake_venv(self, tmpdir):
+        tmpdir.join('bin').ensure_dir()
+        tmpdir.join('lib/python2.7/site-packages').ensure_dir()
+        tmpdir.join('bin/activate').write('VIRTUAL_ENV=/venv')
+        yield tmpdir
+
+    def test_not_a_virtualenv_missing_bindir(self, fake_venv, capsys):
+        fake_venv.join('bin').remove()
+        ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
         out, _ = capsys.readouterr()
-        assert out == 'Error in {}\n'.format(bad_pyc.strpath)
+        assert ret == 1
+        expected = '{} is not a virtualenv: not a directory: {}\n'.format(
+            fake_venv, fake_venv.join('bin'),
+        )
+        assert out == expected
+
+    def test_not_a_virtualenv_missing_activate_file(self, fake_venv, capsys):
+        fake_venv.join('bin/activate').remove()
+        ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
+        out, _ = capsys.readouterr()
+        assert ret == 1
+        expected = '{} is not a virtualenv: not a file: {}\n'.format(
+            fake_venv, fake_venv.join('bin/activate'),
+        )
+        assert out == expected
+
+    version_lib_dir_pattern = 'lib/python{}.{}'
+
+    def test_not_a_virtualenv_missing_versioned_lib_directory(
+        self,
+        fake_venv,
+        capsys
+    ):
+        fake_venv.join(self.version_lib_dir_pattern.format(2, 7)).remove()
+        ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
+        out, _ = capsys.readouterr()
+        assert ret == 1
+        expected = '{} is not a virtualenv: not a directory: {}\n'.format(
+            fake_venv,
+            fake_venv.join(self.version_lib_dir_pattern.format('#', '#')),
+        )
+        assert out == expected
+
+    site_packages_path = 'lib/python2.7/site-packages'
+
+    def test_not_a_virtualenv_missing_site_packages(self, fake_venv, capsys):
+        fake_venv.join(self.site_packages_path).remove()
+        ret = virtualenv_tools.main(('--update-path=auto', fake_venv.strpath))
+        out, _ = capsys.readouterr()
+        assert ret == 1
+        expected = '{} is not a virtualenv: not a directory: {}\n'.format(
+            fake_venv, fake_venv.join(self.site_packages_path),
+        )
+        assert out == expected
 
 
-def test_pypy_dir_oddities(venv_pypy):
-    venv = venv_pypy
-    bindir = venv.before.join('bin')
-    # A directory existing in the bin dir
-    bindir.join('im_a_directory').ensure_dir()
-    # A broken symlink
-    bindir.join('bad_symlink').mksymlinkto('/i/dont/exist')
-    # A file with a shebang-looking start, but not actually
-    bindir.join('not-an-exe').write('#!\nohai')
-    run(venv.before, venv.after)
+class TestVirtualenvToolsFakeVenvPyPy(TestVirtualenvToolsFakeVenv):
 
+    @pytest.yield_fixture
+    def fake_venv(self, tmpdir):
+        tmpdir.join('bin').ensure_dir()
+        tmpdir.join('lib_pypy').ensure_dir()
+        tmpdir.join('site-packages').ensure_dir()
+        tmpdir.join('lib-python/2.7').ensure_dir()
+        tmpdir.join('bin/activate').write('VIRTUAL_ENV=/venv')
+        yield tmpdir
 
-def test_pypy_verbose(venv_pypy, capsys):
-    venv = venv_pypy
-    run(venv.before, venv.after, args=('--verbose',))
-    out, _ = capsys.readouterr()
-    # Lots of output
-    print (out)
-    assert len(out.splitlines()) > 50
-
-
-@pytest.yield_fixture
-def fake_pypy_venv(tmpdir):
-    tmpdir.join('bin').ensure_dir()
-    tmpdir.join('lib_pypy').ensure_dir()
-    tmpdir.join('site-packages').ensure_dir()
-    tmpdir.join('lib-python/2.7').ensure_dir()
-    tmpdir.join('bin/activate').write('VIRTUAL_ENV=/venv')
-    yield tmpdir
-
-
-def test_pypy_not_a_virtualenv_missing_bindir(fake_pypy_venv, capsys):
-    fake_pypy_venv.join('bin').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
-        fake_pypy_venv, fake_pypy_venv.join('bin'),
-    )
-    assert out == expected
-
-
-def test_pypy_not_a_virtualenv_missing_activate_file(fake_pypy_venv, capsys):
-    fake_pypy_venv.join('bin/activate').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a file: {}\n'.format(
-        fake_pypy_venv, fake_pypy_venv.join('bin/activate'),
-    )
-    assert out == expected
-
-
-def test_pypy_not_a_virtualenv_missing_versioned_lib_directory(fake_pypy_venv, capsys):
-    fake_pypy_venv.join('lib-python/2.7').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
-        fake_pypy_venv, fake_pypy_venv.join('lib-python/#.#'),
-    )
-    assert out == expected
-
-
-def test_pypy_not_a_virtualenv_missing_site_packages(fake_pypy_venv, capsys):
-    fake_pypy_venv.join('site-packages').remove()
-    ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
-    out, _ = capsys.readouterr()
-    assert ret == 1
-    expected = '{} is not a virtualenv: not a directory: {}\n'.format(
-        fake_pypy_venv, fake_pypy_venv.join('site-packages'),
-    )
-    assert out == expected
+    version_lib_dir_pattern = 'lib-python/{}.{}'
+    site_packages_path = 'site-packages'

--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -147,6 +147,7 @@ def test_verbose(venv, capsys):
     run(venv.before, venv.after, args=('--verbose',))
     out, _ = capsys.readouterr()
     # Lots of output
+    print (out)
     assert len(out.splitlines()) > 50
 
 
@@ -209,12 +210,147 @@ def test_not_a_virtualenv_missing_site_packages(fake_venv, capsys):
     assert out == expected
 
 
+
+
+# pypy tests temp--------------------
+
+
+@pytest.yield_fixture
+def venv_pypy(tmpdir):
+    app_before = tmpdir.join('before').ensure_dir()
+    app_before.join('mymodule.py').write(
+        "if __name__ == '__main__':\n"
+        "    print('ohai!')\n"
+    )
+    app_before.join('setup.py').write(
+        'from setuptools import setup\n'
+        'setup(name="mymodule", py_modules=["mymodule"])\n'
+    )
+    venv_before = app_before.join('venv')
+    app_after = tmpdir.join('after')
+    venv_after = app_after.join('venv')
+
+    cmd = (sys.executable, '-m', 'virtualenv', venv_before.strpath, '-p', 'pypy')
+    subprocess.check_call(cmd)
+    subprocess.check_call((
+        venv_before.join('bin/pip').strpath,
+        'install', '-e', app_before.strpath,
+    ))
+    yield auto_namedtuple(
+        app_before=app_before, app_after=app_after,
+        before=venv_before, after=venv_after,
+    )
+
+
+def _assert_activated_pypy_sys_executable(path):
+    exe = subprocess.check_output((
+        'bash', '-c',
+        ". {} && pypy -c 'import sys; print(sys.executable)'".format(
+            pipes.quote(path.join('bin/activate').strpath),
+        )
+    )).decode('UTF-8').strip()
+    assert exe == path.join('bin/pypy').strpath
+
+
+def _assert_mymodule_pypy_output(path):
+    out = subprocess.check_output(
+        (path.join('bin/python').strpath, '-m', 'mymodule'),
+        # Run from '/' to ensure we're not importing from .
+        cwd='/',
+    ).decode('UTF-8')
+    assert out == 'ohai!\n'
+
+
+def assert_virtualenv_pypy_state(path):
+    _assert_activated_pypy_sys_executable(path)
+    _assert_mymodule_pypy_output(path)
+
+
+def test_pypy_already_up_to_date(venv_pypy, capsys):
+    run(venv_pypy.before, venv_pypy.before)
+    out, _ = capsys.readouterr()
+    assert out == 'Already up-to-date: {0} ({0})\n'.format(venv_pypy.before)
+
+
+def test_pypy_each_part_idempotent(tmpdir, venv_pypy, capsys):
+    venv = venv_pypy
+    activate = venv.before.join('bin/activate')
+    before_activate_contents = activate.read()
+    run(venv.before, venv.after)
+    capsys.readouterr()
+    # Write the activate file to trick the logic into rerunning
+    activate.write(before_activate_contents)
+    run(venv.before, venv.after, args=('--verbose',))
+    out, _ = capsys.readouterr()
+    # Should only update our activate file:
+    expected = 'A {0}\nUpdated: {1} ({1} -> {2})\n'.format(
+        activate, venv.before, venv.after,
+    )
+    assert out == expected
+
+
+def test_pypy_move(venv_pypy, capsys):
+    venv = venv_pypy
+    assert_virtualenv_pypy_state(venv.before)
+    run(venv.before, venv.after)
+    out, _ = capsys.readouterr()
+    expected = 'Updated: {0} ({0} -> {1})\n'.format(venv.before, venv.after)
+    assert out == expected
+    venv.app_before.move(venv.app_after)
+    assert_virtualenv_pypy_state(venv.after)
+
+
+def test_pypy_move_with_auto(venv_pypy, capsys):
+    venv = venv_pypy
+    venv.app_before.move(venv.app_after)
+    ret = virtualenv_tools.main(('--update-path=auto', venv.after.strpath))
+    out, _ = capsys.readouterr()
+    expected = 'Updated: {1} ({0} -> {1})\n'.format(venv.before, venv.after)
+    assert ret == 0
+    assert out == expected
+    assert_virtualenv_pypy_state(venv.after)
+
+
+def test_pypy_bad_pyc(venv_pypy, capsys):
+    venv = venv_pypy
+    libdir = 'lib-python/{}.{}'.format(*sys.version_info[:2])
+    bad_pyc = venv.before.join(libdir, 'bad.pyc')
+    bad_pyc.write_binary(b'I am a very naughty pyc\n')
+    # Retries on failures as well
+    for _ in range(2):
+        with pytest.raises(ValueError):
+            run(venv.before, venv.after)
+        out, _ = capsys.readouterr()
+        assert out == 'Error in {}\n'.format(bad_pyc.strpath)
+
+
+def test_pypy_dir_oddities(venv_pypy):
+    venv = venv_pypy
+    bindir = venv.before.join('bin')
+    # A directory existing in the bin dir
+    bindir.join('im_a_directory').ensure_dir()
+    # A broken symlink
+    bindir.join('bad_symlink').mksymlinkto('/i/dont/exist')
+    # A file with a shebang-looking start, but not actually
+    bindir.join('not-an-exe').write('#!\nohai')
+    run(venv.before, venv.after)
+
+
+def test_pypy_verbose(venv_pypy, capsys):
+    venv = venv_pypy
+    run(venv.before, venv.after, args=('--verbose',))
+    out, _ = capsys.readouterr()
+    # Lots of output
+    print (out)
+    assert len(out.splitlines()) > 50
+
+
 @pytest.yield_fixture
 def fake_pypy_venv(tmpdir):
     tmpdir.join('bin').ensure_dir()
     tmpdir.join('lib_pypy').ensure_dir()
     tmpdir.join('site-packages').ensure_dir()
-    tmpdir.join('lib-python/py27').ensure_dir()
+    tmpdir.join('lib-python/2.7').ensure_dir()
     tmpdir.join('bin/activate').write('VIRTUAL_ENV=/venv')
     yield tmpdir
 
@@ -242,12 +378,12 @@ def test_pypy_not_a_virtualenv_missing_activate_file(fake_pypy_venv, capsys):
 
 
 def test_pypy_not_a_virtualenv_missing_versioned_lib_directory(fake_pypy_venv, capsys):
-    fake_pypy_venv.join('lib-python/py27').remove()
+    fake_pypy_venv.join('lib-python/2.7').remove()
     ret = virtualenv_tools.main(('--update-path=auto', fake_pypy_venv.strpath))
     out, _ = capsys.readouterr()
     assert ret == 1
     expected = '{} is not a virtualenv: not a directory: {}\n'.format(
-        fake_pypy_venv, fake_pypy_venv.join('lib-python/py##'),
+        fake_pypy_venv, fake_pypy_venv.join('lib-python/#.#'),
     )
     assert out == expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,14 @@ commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 
+[testenv:py35]
+commands =
+    coverage erase
+    coverage run -m pytest {posargs:tests}
+    coverage report --show-missing --fail-under 87
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
+
 [testenv:venv]
 envdir = venv-{[tox]project}
 commands =

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -28,7 +28,7 @@ ACTIVATION_SCRIPTS = [
     'activate.fish'
 ]
 _pybin_match = re.compile(r'^python\d+\.\d+$')
-_pypy_match = re.compile(r'^py\d+\d+$')
+_pypy_match = re.compile(r'^\d+.\d+$')
 _activation_path_re = re.compile(
     r'^(?:set -gx |setenv |)VIRTUAL_ENV[ =]"(.*?)"\s*$',
 )
@@ -293,7 +293,7 @@ def _get_original_state_pypy(path):
     ]
     if len(lib_dirs) != 1:
         raise NotAVirtualenvError(
-            path, 'directory', os.path.join(base_lib_dir, 'py##'),
+            path, 'directory', os.path.join(base_lib_dir, '#.#'),
         )
     lib_dir, = lib_dirs
 

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -28,7 +28,7 @@ ACTIVATION_SCRIPTS = [
     'activate.fish'
 ]
 _pybin_match = re.compile(r'^python\d+\.\d+$')
-_pypy_match = re.compile(r'^\d+\.\d+$')
+_pypy_match = re.compile(r'^py\d+\d+$')
 _activation_path_re = re.compile(
     r'^(?:set -gx |setenv |)VIRTUAL_ENV[ =]"(.*?)"\s*$',
 )
@@ -293,7 +293,7 @@ def _get_original_state_pypy(path):
     ]
     if len(lib_dirs) != 1:
         raise NotAVirtualenvError(
-            path, 'directory', os.path.join(base_lib_dir, '#.#'),
+            path, 'directory', os.path.join(base_lib_dir, 'py##'),
         )
     lib_dir, = lib_dirs
 


### PR DESCRIPTION
Added support for pypy virtualenvs. 
 - Under tox -e py27 test coverage is 100%
 - Under tox -e py35 test coverage is 87% if pypy3 is unavailable (state of dev20-devc)
   - This limitation is due to python3.3+ changing 'magic length' at beginning of pyc files. When the test runner is in py33+ interpreter it is unable to marshal.load() a pyc file in a pypy virtualenv. A pypy3 virtualenv should work fine.

Pardon the amount of lines changed through test refactoring, I initially had copies of every test for a 'pypy' version, but the amount of duplication was driving me crazy so I had to refactor existing tests slightly to allow this duplication to be avoided.

referenced internal yelp ticket is DATAPIPE-2904