### PR TITLE
Add github action to upload to pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,44 @@
+name: pypi
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - env: py38
+          py: '3.8'
+        - env: py39
+          py: '3.9'
+        - env: py310
+          py: '3.10'
+        - env: py311
+          py: '3.11'
+        - env: pypy3.9
+          py: 'pypy-3.9'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.py }}
+    - run: pip install tox
+    - run: tox -e ${{ matrix.env }}
+  pypi:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: python setup.py sdist
+      - uses: pypa/gh-action-pypi-publish@v1.10.3


### PR DESCRIPTION
This uses this OIDC configuration in pypi:

![image](https://github.com/user-attachments/assets/bd89823a-7647-4888-bc8f-9fb63517507b)

so no creds or api key is needed. 