### PR TITLE
Fix virtualenv extraction from activate for newer virtualenvs

### DIFF
--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -284,3 +284,13 @@ def test_virtualenv_path_works_with_nonquoted_path(fake_venv, capsys):
     assert out.startswith('Updated: ')
     assert '/venv ->' in out
 
+
+def test_get_orig_path(venv):
+    activate = venv.before
+    orig_path = virtualenv_tools.get_orig_path(activate)
+    assert orig_path == venv.before.strpath
+
+def test_get_virtualenv_path_from_activate(venv):
+    activate = venv.before
+    venv_path = virtualenv_tools.get_virtualenv_path_from_activate(activate)
+    assert venv_path == venv.before.strpath

--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -289,8 +289,3 @@ def test_get_orig_path(venv):
     activate = venv.before
     orig_path = virtualenv_tools.get_orig_path(activate)
     assert orig_path == venv.before.strpath
-
-def test_get_virtualenv_path_from_activate(venv):
-    activate = venv.before
-    venv_path = virtualenv_tools.get_virtualenv_path_from_activate(activate)
-    assert venv_path == venv.before.strpath

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,5 @@ commands =
 envdir = venv-{[tox]project}
 commands =
 
-[testenv:older-virtualenv]
-commands_pre =
-    pip install "virtualenv<20.36.0"
-
 [pep8]
 ignore = E265,E501,W504

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,9 @@ commands =
 envdir = venv-{[tox]project}
 commands =
 
+[testenv:older-virtualenv]
+commands_pre =
+    pip install "virtualenv<20.36.0"
+
 [pep8]
 ignore = E265,E501,W504

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -247,14 +247,10 @@ def update_paths(venv: Virtualenv, new_path: str) -> None:
     remove_local(venv.path)
     update_scripts(venv.bin_dir, venv.orig_path, new_path, activation=True)
 
-
 def get_orig_path(venv_path: str) -> str:
     """This helps us know whether someone has tried to relocate the
     virtualenv
     """
-    return get_virtualenv_path_from_activate(venv_path)
-
-def get_virtualenv_path_from_activate(venv_path: str) -> str:
     activate_path = os.path.join(venv_path, 'bin/activate')
     result = subprocess.run(["bash", "-c", f"source {activate_path} && echo $VIRTUAL_ENV"], capture_output=True, text=True)
     return result.stdout.strip()

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -18,6 +18,7 @@ import os.path
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 from types import CodeType
 from typing import NamedTuple
@@ -265,6 +266,10 @@ def get_orig_path(venv_path: str) -> str:
                 activate_path
             )
 
+def get_virtualenv_path_from_activate(venv_path: str) -> str:
+    activate_path = os.path.join(venv_path, 'bin/activate')
+    result = subprocess.run(["bash", "-c", f"source {activate_path} && echo $VIRTUAL_ENV"], capture_output=True, text=True)
+    return result.stdout.strip()
 
 class NotAVirtualenvError(ValueError):
     def __str__(self) -> str:

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -252,19 +252,7 @@ def get_orig_path(venv_path: str) -> str:
     """This helps us know whether someone has tried to relocate the
     virtualenv
     """
-    activate_path = os.path.join(venv_path, 'bin/activate')
-
-    with open(activate_path) as activate:
-        venv_var_prefix = 'VIRTUAL_ENV='
-        for line in activate:
-            # virtualenv 20 changes the position
-            if line.startswith(venv_var_prefix):
-                return shlex.split(line[len(venv_var_prefix):])[0]
-        else:
-            raise AssertionError(
-                'Could not find VIRTUAL_ENV= in activation script: %s' %
-                activate_path
-            )
+    return get_virtualenv_path_from_activate(venv_path)
 
 def get_virtualenv_path_from_activate(venv_path: str) -> str:
     activate_path = os.path.join(venv_path, 'bin/activate')


### PR DESCRIPTION
## Problem

pypa/virtualenv#2996 (`virtualenv==20.36.0`) changes how the `VIRTUAL_ENV` variable is defined in the bash activate script. Our tool explicitly reads and parses the activate script for the value of `VIRTUAL_ENV=`, which no longer works with the change and breaks with
```
AssertionError: Could not find VIRTUAL_ENV= in activation script: venv/bin/activate
```

Fixes #34.

## Solution

The parsing is very brittle against changes to the script. Instead, we explicitly source the script and extract the value of the exported env variable.

## Validation

We added a new test `test_get_orig_path`. During development, we tested against both older and newer virtualenv. Our change is compatible with both so we don't need to explicitly test different virtualenvs.

## Note

HLFH in #34 provided their own patch in their fork for this change in https://github.com/HLFH/virtualenv-tools/commit/497153249d812794f94583e760e604793e722bbd, but it seems to be targeting a different form of the activation script.