### PR TITLE
Fix virtualenv update for new bash activation script

### DIFF
--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -289,3 +289,52 @@ def test_get_orig_path(venv):
     activate = venv.before
     orig_path = virtualenv_tools.get_orig_path(activate)
     assert orig_path == venv.before.strpath
+
+
+@pytest.mark.parametrize(
+    'script_name',
+    [
+        'activate',
+        'activate.csh',
+        'activate.fish',
+        pytest.param('activate.xsh', marks=pytest.mark.xfail(reason='activate.xsh removed in virtualenv 20.7.0')),
+    ],
+)
+def test_update_activation_script(venv, script_name):
+    """Test update_activation_script updates activation scripts."""
+    script_path = venv.before.join(f'bin/{script_name}').strpath
+
+    # Read original content to verify it has the old path
+    with open(script_path) as f:
+        original_content = f.read()
+    assert venv.before.strpath in original_content
+
+    # Update the activation script
+    virtualenv_tools.update_activation_script(script_path, venv.after.strpath)
+
+    # Verify the new path is in the file
+    with open(script_path) as f:
+        updated_content = f.read()
+    assert venv.after.strpath in updated_content
+    assert venv.before.strpath not in updated_content
+
+
+def test_update_activation_script_no_change_when_already_updated(venv):
+    """Test that update_activation_script doesn't modify file if path is already correct."""
+    activate_path = venv.before.join('bin/activate').strpath
+
+    # First update to the new path
+    virtualenv_tools.update_activation_script(activate_path, venv.after.strpath)
+
+    # Read the content after first update
+    with open(activate_path) as f:
+        content_after_first = f.read()
+
+    # Try updating again with the same path
+    virtualenv_tools.update_activation_script(activate_path, venv.after.strpath)
+
+    # Verify content hasn't changed
+    with open(activate_path) as f:
+        content_after_second = f.read()
+
+    assert content_after_first == content_after_second

--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -284,3 +284,8 @@ def test_virtualenv_path_works_with_nonquoted_path(fake_venv, capsys):
     assert out.startswith('Updated: ')
     assert '/venv ->' in out
 
+
+def test_get_orig_path(venv):
+    activate = venv.before
+    orig_path = virtualenv_tools.get_orig_path(activate)
+    assert orig_path == venv.before.strpath

--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -310,7 +310,7 @@ def test_update_activation_script(venv, script_name):
     assert venv.before.strpath in original_content
 
     # Update the activation script
-    virtualenv_tools.update_activation_script(script_path, venv.after.strpath)
+    virtualenv_tools.update_activation_script(script_path, venv.before.strpath, venv.after.strpath)
 
     # Verify the new path is in the file
     with open(script_path) as f:
@@ -324,14 +324,14 @@ def test_update_activation_script_no_change_when_already_updated(venv):
     activate_path = venv.before.join('bin/activate').strpath
 
     # First update to the new path
-    virtualenv_tools.update_activation_script(activate_path, venv.after.strpath)
+    virtualenv_tools.update_activation_script(activate_path, venv.before.strpath, venv.after.strpath)
 
     # Read the content after first update
     with open(activate_path) as f:
         content_after_first = f.read()
 
     # Try updating again with the same path
-    virtualenv_tools.update_activation_script(activate_path, venv.after.strpath)
+    virtualenv_tools.update_activation_script(activate_path, venv.before.strpath, venv.after.strpath)
 
     # Verify content hasn't changed
     with open(activate_path) as f:

--- a/tests/virtualenv_tools_test.py
+++ b/tests/virtualenv_tools_test.py
@@ -310,7 +310,7 @@ def test_update_activation_script(venv, script_name):
     assert venv.before.strpath in original_content
 
     # Update the activation script
-    virtualenv_tools.update_activation_script(script_path, venv.before.strpath, venv.after.strpath)
+    virtualenv_tools.update_activation_script(script_path, venv.after.strpath)
 
     # Verify the new path is in the file
     with open(script_path) as f:
@@ -324,14 +324,14 @@ def test_update_activation_script_no_change_when_already_updated(venv):
     activate_path = venv.before.join('bin/activate').strpath
 
     # First update to the new path
-    virtualenv_tools.update_activation_script(activate_path, venv.before.strpath, venv.after.strpath)
+    virtualenv_tools.update_activation_script(activate_path, venv.after.strpath)
 
     # Read the content after first update
     with open(activate_path) as f:
         content_after_first = f.read()
 
     # Try updating again with the same path
-    virtualenv_tools.update_activation_script(activate_path, venv.before.strpath, venv.after.strpath)
+    virtualenv_tools.update_activation_script(activate_path, venv.after.strpath)
 
     # Verify content hasn't changed
     with open(activate_path) as f:

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,5 @@ commands =
 envdir = venv-{[tox]project}
 commands =
 
-[testenv:older-virtualenv]
-commands_pre =
-    pip install "virtualenv<20.36.0"
-
 [pep8]
 ignore = E265,E501,W504

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,9 @@ commands =
 envdir = venv-{[tox]project}
 commands =
 
+[testenv:older-virtualenv]
+commands_pre =
+    pip install "virtualenv<20.36.0"
+
 [pep8]
 ignore = E265,E501,W504

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -220,7 +220,7 @@ def update_pycs(lib_dir: str, new_path: str) -> None:
                 update_pyc(filename, local_path)
 
 
-def _update_pth_file(pth_filename: str, orig_path: str) -> None:
+def _update_pth_file(pth_filename: str, orig_path: str) -> None: # pragma: <3.9 cover
     with open(pth_filename) as f:
         lines = f.readlines()
     changed = False
@@ -251,6 +251,40 @@ def update_pth_files(site_packages: str, orig_path: str) -> None:
             _update_pth_file(filename, orig_path)
 
 
+def _update_editable_finder_file(filepath: str, orig_path: str, new_path: str) -> None:  # pragma: >=3.9 cover
+    with open(filepath) as f:
+        lines = f.readlines()
+    changed = False
+    orig_parent = os.path.dirname(orig_path)
+    new_parent = os.path.dirname(new_path)
+    for i, line in enumerate(lines):
+        if orig_parent not in line:
+            continue
+        changed = True
+        new_line = ''
+        pos = 0
+        while True:
+            idx = line.find(orig_parent, pos)
+            if idx == -1:
+                new_line += line[pos:]
+                break
+            new_line += line[pos:idx] + new_parent
+            pos = idx + len(orig_parent)
+        lines[i] = new_line
+    if changed:
+        with open(filepath, 'w') as f:
+            f.write(''.join(lines))
+        debug(f'F {filepath}')
+
+
+def update_editable_finder_files(site_packages: str, orig_path: str, new_path: str) -> None:  # pragma: >=3.9 cover
+    """Updates paths in editable install finder files created by modern pip."""
+    for filename in os.listdir(site_packages):
+        filepath = os.path.join(site_packages, filename)
+        if filename.startswith('__editable__') and filename.endswith('_finder.py') and os.path.isfile(filepath):
+                _update_editable_finder_file(filepath, orig_path, new_path)
+
+
 def remove_local(base: str) -> None:
     """On some systems virtualenv seems to have something like a local
     directory with symlinks.  This directory is safe to remove in modern
@@ -268,6 +302,7 @@ def update_paths(venv: Virtualenv, new_path: str) -> None:
     for lib_dir in venv.lib_dirs:
         update_pycs(lib_dir, new_path)
     update_pth_files(venv.site_packages, venv.orig_path)
+    update_editable_finder_files(venv.site_packages, venv.orig_path, new_path)
     remove_local(venv.path)
     update_scripts(venv.bin_dir, venv.orig_path, new_path, activation=True)
 

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -57,7 +57,7 @@ def debug(msg: str) -> None:
     if VERBOSE:
         print(msg)
 
-def update_activation_script(script_filename: str, old_path: str, new_path: str) -> None:
+def update_activation_script(script_filename: str, new_path: str) -> None:
     """Updates the paths for the activate shell scripts."""
     with open(script_filename) as f:
         lines = list(f)
@@ -168,7 +168,7 @@ def update_scripts(
     for fname in os.listdir(bin_dir):
         path = os.path.join(bin_dir, fname)
         if fname in ACTIVATION_SCRIPTS and activation:
-            update_activation_script(path, orig_path, new_path)
+            update_activation_script(path, new_path)
         elif os.path.isfile(path):
             update_script(path, orig_path, new_path)
 

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -257,7 +257,7 @@ def get_orig_path(venv_path: str) -> str:
         venv_var_prefix = 'VIRTUAL_ENV='
         for line in activate:
             # virtualenv 20 changes the position
-            venv_var_line = line
+            venv_var_line = line.strip()
             if venv_var_line.startswith(venv_var_prefix):
                 return shlex.split(venv_var_line[len(venv_var_prefix):])[0]
         else:

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -257,8 +257,9 @@ def get_orig_path(venv_path: str) -> str:
         venv_var_prefix = 'VIRTUAL_ENV='
         for line in activate:
             # virtualenv 20 changes the position
-            if line.startswith(venv_var_prefix):
-                return shlex.split(line[len(venv_var_prefix):])[0]
+            venv_var_line = line
+            if venv_var_line.startswith(venv_var_prefix):
+                return shlex.split(venv_var_line[len(venv_var_prefix):])[0]
         else:
             raise AssertionError(
                 'Could not find VIRTUAL_ENV= in activation script: %s' %

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -35,6 +35,16 @@ _pypy_match = re.compile(r'^pypy\d+.\d+$')
 _activation_path_re = re.compile(
     r'^(?:set -gx |setenv |)VIRTUAL_ENV[ =][\'"]?(.*?)[\'"]?\s*$',
 )
+# Bash activate script patterns (for virtualenv 20.36.0+)
+_bash_if_check_re = re.compile(
+    r'^if \[ ! -d (.+?)(?: \]; then.*)',
+)
+_bash_echo_path_re = re.compile(
+    r'^(?:\s*)echo "Virtual environment directory (.+?)(?: does not exist!" >&2.*)',
+)
+_bash_virtual_env_re = re.compile(
+    r'^(?:\s*)VIRTUAL_ENV=(?![\'"]?\$)[\'"]?([^\s\'"]+)(?:[\'"]?\s*)',
+)
 VERBOSE = False
 # magic length
 # + 4 byte timestamp
@@ -63,7 +73,14 @@ def update_activation_script(script_filename: str, old_path: str, new_path: str)
         if os.path.basename(script_filename) == 'activate':
             # The bash activate script changed in virtualenv 20.36.0.
             # It now has multiple references to the old_path that don't match the original regex
-            new_line = line.replace(old_path, new_path)
+            # We need to handle multiple patterns:
+            # 1. if [ ! -d /path ]; then
+            # 2.     echo "Virtual environment directory /path does not exist!" >&2
+            # 3.     VIRTUAL_ENV=/path or VIRTUAL_ENV='/path' (with leading whitespace)
+            new_line = line
+            new_line = _bash_if_check_re.sub(_handle_sub, new_line)
+            new_line = _bash_echo_path_re.sub(_handle_sub, new_line)
+            new_line = _bash_virtual_env_re.sub(_handle_sub, new_line)
             if line != new_line:
                 lines[idx] = new_line
                 changed = True

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -259,7 +259,8 @@ def get_orig_path(venv_path: str) -> str:
             # virtualenv 20 changes the position
             venv_var_line = line.strip()
             if venv_var_line.startswith(venv_var_prefix):
-                return shlex.split(venv_var_line[len(venv_var_prefix):])[0]
+                venv_var_value = shlex.split(venv_var_line[len(venv_var_prefix):])[0]
+                return venv_var_value
         else:
             raise AssertionError(
                 'Could not find VIRTUAL_ENV= in activation script: %s' %

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -60,10 +60,19 @@ def update_activation_script(script_filename: str, old_path: str, new_path: str)
 
     changed = False
     for idx, line in enumerate(lines):
-        new_line = _activation_path_re.sub(_handle_sub, line)
-        if line != new_line:
-            lines[idx] = new_line
-            changed = True
+        if os.path.basename(script_filename) == 'activate':
+            # The bash activate script changed in virtualenv 20.36.0.
+            # It now has multiple references to the old_path that don't match the original regex
+            new_line = line.replace(old_path, new_path)
+            if line != new_line:
+                lines[idx] = new_line
+                changed = True
+        else:
+            new_line = _activation_path_re.sub(_handle_sub, line)
+            if line != new_line:
+                lines[idx] = new_line
+                changed = True
+
 
     if changed:
         debug('A %s' % script_filename)

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -260,7 +260,10 @@ def get_orig_path(venv_path: str) -> str:
             venv_var_line = line.strip()
             if venv_var_line.startswith(venv_var_prefix):
                 venv_var_value = shlex.split(venv_var_line[len(venv_var_prefix):])[0]
-                return venv_var_value
+                # This value could be a bash expression or a path.
+                # Validate it's a path-like string.
+                if os.path.isabs(venv_var_value):
+                    return venv_var_value
         else:
             raise AssertionError(
                 'Could not find VIRTUAL_ENV= in activation script: %s' %

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -81,14 +81,12 @@ def update_activation_script(script_filename: str, new_path: str) -> None:
             new_line = _bash_if_check_re.sub(_handle_sub, new_line)
             new_line = _bash_echo_path_re.sub(_handle_sub, new_line)
             new_line = _bash_virtual_env_re.sub(_handle_sub, new_line)
-            if line != new_line:
-                lines[idx] = new_line
-                changed = True
         else:
             new_line = _activation_path_re.sub(_handle_sub, line)
-            if line != new_line:
-                lines[idx] = new_line
-                changed = True
+
+        if line != new_line:
+            lines[idx] = new_line
+            changed = True
 
 
     if changed:

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -47,8 +47,7 @@ def debug(msg: str) -> None:
     if VERBOSE:
         print(msg)
 
-
-def update_activation_script(script_filename: str, new_path: str) -> None:
+def update_activation_script(script_filename: str, old_path: str, new_path: str) -> None:
     """Updates the paths for the activate shell scripts."""
     with open(script_filename) as f:
         lines = list(f)
@@ -143,7 +142,7 @@ def update_scripts(
     for fname in os.listdir(bin_dir):
         path = os.path.join(bin_dir, fname)
         if fname in ACTIVATION_SCRIPTS and activation:
-            update_activation_script(path, new_path)
+            update_activation_script(path, orig_path, new_path)
         elif os.path.isfile(path):
             update_script(path, orig_path, new_path)
 


### PR DESCRIPTION
## Problem

pypa/virtualenv#2996 (`virtualenv==20.36.0`) changes how the `VIRTUAL_ENV` variable is defined in the bash activate script. Our tool explicitly reads and parses the activate script for the value of `VIRTUAL_ENV=`, which no longer works with the change and breaks with
```
AssertionError: Could not find VIRTUAL_ENV= in activation script: venv/bin/activate
```

Additionally, the upstream changes add an explicit exists check for `VIRTUAL_ENV`. This must also be changed.

Fixes #34.

## Solution

Because there are now multiple references to `VIRTUALENV_ENV` path in the bash activation, we must replace them all. We will handle this script differently from the rest of the scripts uses bash-specific regexes.


## Validation

We added a new test `test_get_orig_path` and `test_update_activation_script`. During development, we tested against both older and newer virtualenv. Our change is compatible with both so we don't need to explicitly test different virtualenvs.

## Note

HLFH in #34 provided their own patch in their fork for this change in https://github.com/HLFH/virtualenv-tools/commit/497153249d812794f94583e760e604793e722bbd, but it seems to be targeting a different form of the activation script.

## Notes

This is an alternative approach to #35 